### PR TITLE
Typo on link graphclasses.org

### DIFF
--- a/_posts/2019-10-17-patterns-1.md
+++ b/_posts/2019-10-17-patterns-1.md
@@ -37,7 +37,7 @@ are not expanders, so let's look at what road networks look like.
 
 To be fair, there is a problem with graph classes: 
 there are way too many of them! The website 
-[graphclasses.org](graphclasses.org) lists 1600 classes, and it's 
+[graphclasses.org](http://graphclasses.org) lists 1600 classes, and it's 
 difficult to navigate in this jungle, to know what is an interesting
 class, to know whether the class you're working on is known etc.
 (although the website is very useful for that).


### PR DESCRIPTION
Typo on link graphclasses.org

![Capture d’écran_2019-10-18_16-01-38](https://user-images.githubusercontent.com/11994719/67100840-b7bad380-f1c0-11e9-8215-9abb76dbbbcd.png)
